### PR TITLE
l-loader: Add a generate_mbr.sh script and update Makefile to generat…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ OBJCOPY=$(CROSS_COMPILE)objcopy
 TEXT_BASE=0x1000
 LLOADER_LEN=960K
 
-all: l-loader.bin
+all: l-loader.bin mbr.bin
+	dd if=mbr.bin of=fastboot.bin bs=512 count=1
+	dd obs=512 ibs=512 seek=1 skip=1 if=l-loader.bin of=fastboot.bin conv=notrunc
+
 l-loader.bin: start.S debug.S
 	$(CC) -c -o start.o start.S -DTEXT_BASE=${TEXT_BASE}
 	$(CC) -c -o debug.o debug.S
@@ -25,5 +28,8 @@ l-loader.bin: start.S debug.S
 	$(OBJCOPY) -O binary l-loader temp.bin
 	dd if=temp.bin of=l-loader.bin bs=${LLOADER_LEN} count=1 conv=sync
 
+mbr.bin:
+	bash -x generate_mbr.sh;
+
 clean:
-	rm -f *.o l-loader l-loader.bin temp.bin temp
+	rm -f *.o l-loader l-loader.bin temp.bin temp mbr.bin fastboot.bin

--- a/generate_mbr.sh
+++ b/generate_mbr.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Generate partition table for Poplar eMMC
+#
+# linux: 3 entries
+PTABLE=linux-8g
+TEMP_FILE=$(mktemp /tmp/${PTABLE}.XXXXXX)
+
+#Poplar has 8gb eMMC
+SECTOR_NUMBER=15269888
+SECTOR_SIZE_BYTES=512
+SIZE=$((${SECTOR_NUMBER} * ${SECTOR_SIZE_BYTES}))
+
+echo "Creating MBR for Poplar eMMC"
+
+# get the partition table
+case ${PTABLE} in
+    linux*)
+      truncate --size=$SIZE ${TEMP_FILE}
+
+#mbr.bin1             1     8191     8191     4M f0 Linux/PA-RISC boot
+#mbr.bin2   *      8192   287527   279336 136.4M  c W95 FAT32 (LBA)
+#mbr.bin3        288768 15269887 14981120   7.1G 83 Linux
+
+      sfdisk ${TEMP_FILE} <<EOF
+1, 8191, f0
+,279336, 0c *
+,, 83
+EOF
+
+      ;;
+esac
+
+#extract the mbr
+dd if=${TEMP_FILE} of=mbr.bin bs=${SECTOR_SIZE_BYTES} count=1
+rm -f ${TEMP_FILE}


### PR DESCRIPTION
…e mbr.bin

This commit adds a script to generate a master boot record mbr.bin, and updates
the Makefile to append the mbr.bin and l-loader.bin binaries to output a
fastboot.bin. fastboot.bin can then be consumed easily by the OE build system, and
the build artifiact can be USB booted / flashed to eMMC without any
further processing.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>

Changes since v1:
 * Use truncate rather than dd
 * update to 8191 for first partition
 * specify obs and ibs for dd