### PR TITLE
generate_mbr.sh: Remove --no-reread --no-tell-kernel sfdisk arguments

### DIFF
--- a/generate_mbr.sh
+++ b/generate_mbr.sh
@@ -32,7 +32,7 @@ truncate --size=${SIZE} ${TEMP_FILE}
 	echo "start=1      size=8191     type=f0"
 	echo "start=8192   size=279336   type=0c bootable"
 	echo "start=288768 size=14981120 type=83"
-} | sfdisk --quiet --no-reread --no-tell-kernel ${TEMP_FILE}
+} | sfdisk --quiet ${TEMP_FILE}
 
 # Extract just the MBR
 dd status=none if=${TEMP_FILE} of=mbr.bin bs=${SECTOR_SIZE_BYTES} count=1


### PR DESCRIPTION
These arguments are neither portable between distros nor useful when
sfdisk is running, as it is here, on a file rather than on a device.

Fixes: f692a0717e0b ("generate_mbr.sh: do some major cleanup for
readability")
Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>